### PR TITLE
Add DeepSeek model config

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@ PORT=3001
 # Deepseek Configuration (for AI-powered prompt optimization)
 # Get your API key from: https://platform.deepseek.com/api_keys
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
+DEEPSEEK_MODEL=deepseek-chat
 
 # Supabase Configuration (for user authentication and favorites)
 # IMPORTANT: Replace these with your actual Supabase project credentials

--- a/DEEPSEEK_SETUP.md
+++ b/DEEPSEEK_SETUP.md
@@ -20,6 +20,7 @@
    在 `.env` 文件中设置您的 Deepseek API Key：
    ```
    DEEPSEEK_API_KEY=your_actual_deepseek_api_key_here
+   DEEPSEEK_MODEL=deepseek-chat
    ```
 
 ## 🔧 模型配置

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@
    
    编辑 `.env` 文件，添加必要的配置：
    ```
-   PORT=3001
-   DEEPSEEK_API_KEY=your_deepseek_api_key_here          # 必需，用于AI功能
-   VITE_SUPABASE_URL=your_supabase_project_url          # 可选，用于用户认证
-   VITE_SUPABASE_ANON_KEY=your_supabase_anon_key        # 可选，用于用户认证
+  PORT=3001
+  DEEPSEEK_API_KEY=your_deepseek_api_key_here          # 必需，用于AI功能
+  DEEPSEEK_MODEL=deepseek-chat                         # 默认 DeepSeek 模型
+  VITE_SUPABASE_URL=your_supabase_project_url          # 可选，用于用户认证
+  VITE_SUPABASE_ANON_KEY=your_supabase_anon_key        # 可选，用于用户认证
    ```
    
    **注意**：如果不配置Supabase，应用仍可运行，但用户认证功能将被禁用。

--- a/VERCEL_DEPLOYMENT.md
+++ b/VERCEL_DEPLOYMENT.md
@@ -32,6 +32,7 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # DeepSeek API Configuration (后端需要)
 DEEPSEEK_API_KEY=your_deepseek_api_key
+DEEPSEEK_MODEL=deepseek-chat
 DEEPSEEK_API_URL=https://api.deepseek.com
 
 # Stripe Configuration (如果启用支付)

--- a/deploy.md
+++ b/deploy.md
@@ -13,8 +13,9 @@
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 
-# DeepSeek API Configuration  
+# DeepSeek API Configuration
 DEEPSEEK_API_KEY=your_deepseek_api_key
+DEEPSEEK_MODEL=deepseek-chat
 DEEPSEEK_API_URL=https://api.deepseek.com
 
 # Server Configuration

--- a/env.example
+++ b/env.example
@@ -3,6 +3,7 @@ PORT=3001
 
 # Deepseek Configuration (for AI-powered prompt optimization)
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
+DEEPSEEK_MODEL=deepseek-chat
 
 # Supabase Configuration (for user authentication)
 VITE_SUPABASE_URL=your_supabase_project_url_here

--- a/server/index.js
+++ b/server/index.js
@@ -16,8 +16,10 @@ app.use(express.json())
 console.log('🔍 Debug: DEEPSEEK_API_KEY exists:', !!process.env.DEEPSEEK_API_KEY)
 console.log('🔍 Debug: DEEPSEEK_API_KEY value:', process.env.DEEPSEEK_API_KEY ? `${process.env.DEEPSEEK_API_KEY.substring(0, 6)}...` : 'null')
 
-const deepseek = process.env.DEEPSEEK_API_KEY && 
-                 process.env.DEEPSEEK_API_KEY !== 'your_deepseek_api_key_here' ? 
+const deepseekModel = process.env.DEEPSEEK_MODEL || 'deepseek-chat'
+
+const deepseek = process.env.DEEPSEEK_API_KEY &&
+                 process.env.DEEPSEEK_API_KEY !== 'your_deepseek_api_key_here' ?
   new OpenAI({
     apiKey: process.env.DEEPSEEK_API_KEY,
     baseURL: 'https://api.deepseek.com/v1',
@@ -84,7 +86,7 @@ async function optimizePromptWithAI(prompt, strategy) {
     console.log('🤖 Using Deepseek API')
     try {
       const response = await deepseek.chat.completions.create({
-        model: "deepseek-chat",
+        model: deepseekModel,
         messages: [
           {
             role: "system",

--- a/test-deepseek.js
+++ b/test-deepseek.js
@@ -5,6 +5,8 @@ dotenv.config()
 
 console.log('=== Testing Deepseek API Connection ===')
 
+const deepseekModel = process.env.DEEPSEEK_MODEL || 'deepseek-chat'
+
 const deepseek = new OpenAI({
   apiKey: process.env.DEEPSEEK_API_KEY,
   baseURL: 'https://api.deepseek.com/v1',
@@ -16,7 +18,7 @@ async function testDeepseekAPI() {
     console.log('Sending test request to Deepseek API...')
     
     const response = await deepseek.chat.completions.create({
-      model: "deepseek-chat",
+      model: deepseekModel,
       messages: [
         {
           role: "system",


### PR DESCRIPTION
## Summary
- support configuring DeepSeek model via `DEEPSEEK_MODEL`
- document new env var in README and docs
- update test and server to use `DEEPSEEK_MODEL`

## Testing
- `node test-env.js` *(fails: cannot find module 'dotenv')*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68876c6ff8f8832c9237e0053bb4acf6